### PR TITLE
Introduce multiple frames comparison

### DIFF
--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,4 +1,4 @@
-export const testingSize = 800;
+export const testingSize = 500;
 export const size = 100;
 export const successPercentage = 98;
 export const loadTimeout = 3000;

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -11,7 +11,8 @@ export const diffCanvas = async (canvas: any, targetCanvas: any): Promise<number
       const diffImg = document.querySelector('#diff-img') as any;
       diffImg.src = getImageDataUrl();
       
-      resolve(100 - misMatchPercentage);
+      const result = parseFloat((100 - misMatchPercentage).toFixed(2));
+      resolve(result);
     });
   });
 }


### PR DESCRIPTION
Issue: #5
Improve testing strategy by testing with multiple frames rather than one.

![CleanShot 2024-08-16 at 14 46 56@2x](https://github.com/user-attachments/assets/751dccb6-861e-4023-89c4-34623164ed99)

System grabs 5 testing points from frames (0%, 25%, 50%, 75% 100%), then compares them to expectation.
The final similarity will be calculated, based on the average value.